### PR TITLE
feat: Support deserializing / serializing Option<http::*>

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,6 +33,8 @@
 //! }
 //! ```
 
+pub mod option;
+
 /// For `http::HeaderMap`
 ///
 /// `#[serde(with = "http_serde::header_map")]`
@@ -87,8 +89,8 @@ pub mod header_map {
         Bytes(Vec<Cow<'a, [u8]>>),
     }
 
-    struct HeaderMapVisitor {
-        is_human_readable: bool,
+    pub(crate) struct HeaderMapVisitor {
+        pub(crate) is_human_readable: bool,
     }
 
     impl<'de> Visitor<'de> for HeaderMapVisitor {
@@ -175,7 +177,7 @@ pub mod status_code {
         ser.serialize_u16(status.as_u16())
     }
 
-    struct StatusVisitor;
+    pub(crate) struct StatusVisitor;
 
     impl<'de> Visitor<'de> for StatusVisitor {
         type Value = StatusCode;
@@ -238,7 +240,7 @@ pub mod method {
         ser.serialize_str(method.as_str())
     }
 
-    struct MethodVisitor;
+    pub(crate) struct MethodVisitor;
 
     impl<'de> Visitor<'de> for MethodVisitor {
         type Value = Method;
@@ -278,7 +280,7 @@ pub mod uri {
         ser.collect_str(&uri)
     }
 
-    struct UriVisitor;
+    pub(crate) struct UriVisitor;
 
     impl<'de> Visitor<'de> for UriVisitor {
         type Value = Uri;
@@ -322,7 +324,7 @@ pub mod authority {
         ser.collect_str(&authority)
     }
 
-    struct AuthorityVisitor;
+    pub(crate) struct AuthorityVisitor;
 
     impl<'de> Visitor<'de> for AuthorityVisitor {
         type Value = Authority;
@@ -363,7 +365,7 @@ pub mod version {
         ser.serialize_str(format!("{:?}", version).as_str())
     }
 
-    struct VersionVisitor;
+    pub(crate) struct VersionVisitor;
 
     impl<'de> Visitor<'de> for VersionVisitor {
         type Value = Version;

--- a/src/option.rs
+++ b/src/option.rs
@@ -1,4 +1,34 @@
 //! For `Option<http::*>`
+//!
+//! ## Usage
+//!
+//! You must annotate fields with `#[serde(with = "http_serde::option::<appropriate method>")]`.
+//!
+//! ```rust
+//! use http::*;
+//! use serde::{Serialize, Deserialize};
+//!
+//! #[derive(Serialize, Deserialize)]
+//! struct MyStruct {
+//!     #[serde(with = "http_serde::option::header_map")]
+//!     headers: Option<HeaderMap>,
+//!
+//!     #[serde(with = "http_serde::option::status_code")]
+//!     status: Option<StatusCode>,
+//!
+//!     #[serde(with = "http_serde::option::method")]
+//!     method: Option<Method>,
+//!
+//!     #[serde(with = "http_serde::option::uri")]
+//!     uri: Option<Uri>,
+//!
+//!     #[serde(with = "http_serde::option::authority")]
+//!     authority: Option<uri::Authority>,
+//!
+//!     #[serde(with = "http_serde::option::version")]
+//!     version: Option<Version>,
+//! }
+//! ```
 
 use serde::de::{Error, MapAccess, Visitor};
 use serde::{Deserializer, Serializer};

--- a/src/option.rs
+++ b/src/option.rs
@@ -1,0 +1,76 @@
+//! For `Option<http::*>`
+
+use serde::de::{Error, MapAccess, Visitor};
+use serde::{Deserializer, Serializer};
+use std::fmt;
+use std::fmt::Formatter;
+
+macro_rules! impl_visit {
+    ($name: ident, $type: ty) => {
+        fn $name<E>(self, v: $type) -> Result<Self::Value, E> where E: Error {
+            self.0.$name(v).map(|v| Some(v))
+        }
+    }
+}
+
+struct OptionVisitor<V>(V);
+impl<'de, T, V> Visitor<'de> for OptionVisitor<V>
+where
+    V: Visitor<'de, Value = T>,
+{
+    type Value = Option<T>;
+
+    fn expecting(&self, formatter: &mut Formatter) -> fmt::Result {
+        write!(formatter, "valid option")
+    }
+
+    fn visit_map<M>(self, access: M) -> Result<Self::Value, M::Error>
+        where
+            M: MapAccess<'de>,
+    {
+        self.0.visit_map(access).map(|v| Some(v))
+    }
+
+    impl_visit!(visit_i32, i32);
+    impl_visit!(visit_i16, i16);
+    impl_visit!(visit_u8, u8);
+    impl_visit!(visit_u32, u32);
+    impl_visit!(visit_i64, i64);
+    impl_visit!(visit_u64, u64);
+    impl_visit!(visit_u16, u16);
+    impl_visit!(visit_str, &str);
+    impl_visit!(visit_string, String);
+}
+
+macro_rules! impl_option_with {
+    ($name: ident, $value: ty, $visitor: expr) => {
+        /// For `Option<$value>`
+        ///
+        /// `#[serde(with = "http_serde::option::$name")]`
+        pub mod $name {
+            use super::*;
+
+            pub fn serialize<S: Serializer>(v: &Option<$value>, ser: S) -> Result<S::Ok, S::Error> {
+                match v {
+                    Some(v) => crate::$name::serialize(v, ser),
+                    None => ser.serialize_none(),
+                }
+            }
+
+            pub fn deserialize<'de, D>(de: D) -> Result<Option<$value>, D::Error>
+                where
+                    D: Deserializer<'de>,
+            {
+                let is_human_readable = de.is_human_readable();
+                de.deserialize_option(OptionVisitor($visitor(is_human_readable)))
+            }
+        }
+    }
+}
+
+impl_option_with!(header_map, http::HeaderMap, |is_human_readable: bool| crate::header_map::HeaderMapVisitor { is_human_readable });
+impl_option_with!(status_code, http::StatusCode, |_| crate::status_code::StatusVisitor);
+impl_option_with!(method, http::Method, |_| crate::method::MethodVisitor);
+impl_option_with!(uri, http::Uri, |_| crate::uri::UriVisitor);
+impl_option_with!(authority, http::uri::Authority, |_| crate::authority::AuthorityVisitor);
+impl_option_with!(version, http::Version, |_| crate::version::VersionVisitor);

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -76,3 +76,109 @@ fn roundtrip() {
         assert_eq!(format!("{:?}", back.5), "HTTP/2.0");
     }
 }
+
+#[test]
+fn option_header_map() {
+    use http::{HeaderMap, HeaderValue};
+
+    #[derive(serde::Serialize, serde::Deserialize)]
+    struct Wrap(
+        #[serde(with = "http_serde::option::header_map")]
+        Option<HeaderMap>,
+    );
+
+    let mut map = HeaderMap::new();
+    map.insert("Authorization", HeaderValue::from_str("Bearer").unwrap());
+
+    let wrap = Wrap(Some(map));
+    assert_eq!(r#"{"authorization":"Bearer"}"#.to_owned(), serde_json::to_string(&wrap).unwrap());
+
+    let wrap = Wrap(None);
+    assert_eq!("null".to_owned(), serde_json::to_string(&wrap).unwrap());
+}
+
+#[test]
+fn option_status_code() {
+    use http::StatusCode;
+
+    #[derive(serde::Serialize, serde::Deserialize)]
+    struct Wrap(
+        #[serde(with = "http_serde::option::status_code")]
+        Option<StatusCode>,
+    );
+
+    let wrap = Wrap(Some(StatusCode::OK));
+    assert_eq!("200".to_owned(), serde_json::to_string(&wrap).unwrap());
+
+    let wrap = Wrap(None);
+    assert_eq!("null".to_owned(), serde_json::to_string(&wrap).unwrap());
+}
+
+#[test]
+fn option_method() {
+    use http::Method;
+
+    #[derive(serde::Serialize, serde::Deserialize)]
+    struct Wrap(
+        #[serde(with = "http_serde::option::method")]
+        Option<Method>,
+    );
+
+    let wrap = Wrap(Some(Method::POST));
+    assert_eq!(r#""POST""#.to_owned(), serde_json::to_string(&wrap).unwrap());
+
+    let wrap = Wrap(None);
+    assert_eq!("null".to_owned(), serde_json::to_string(&wrap).unwrap());
+}
+
+#[test]
+fn option_uri() {
+    use http::Uri;
+
+    #[derive(serde::Serialize, serde::Deserialize)]
+    struct Wrap(
+        #[serde(with = "http_serde::option::uri")]
+        Option<Uri>,
+    );
+
+    let wrap = Wrap(Some("https://example.com/".parse().unwrap()));
+    assert_eq!(r#""https://example.com/""#.to_owned(), serde_json::to_string(&wrap).unwrap());
+
+    let wrap = Wrap(None);
+    assert_eq!("null".to_owned(), serde_json::to_string(&wrap).unwrap());
+}
+
+#[test]
+fn option_authority() {
+    use std::str::FromStr;
+    use http::uri::Authority;
+
+    #[derive(serde::Serialize, serde::Deserialize)]
+    struct Wrap(
+        #[serde(with = "http_serde::option::authority")]
+        Option<Authority>,
+    );
+
+    let wrap = Wrap(Some(Authority::from_str("example.com").unwrap()));
+    assert_eq!(r#""example.com""#.to_owned(), serde_json::to_string(&wrap).unwrap());
+
+    let wrap = Wrap(None);
+    assert_eq!("null".to_owned(), serde_json::to_string(&wrap).unwrap());
+}
+
+#[test]
+fn option_version() {
+    use http::Version;
+
+    #[derive(serde::Serialize, serde::Deserialize)]
+    struct Wrap(
+        #[serde(with = "http_serde::option::version")]
+        Option<Version>,
+    );
+
+    let wrap = Wrap(Some(Version::HTTP_11));
+    assert_eq!(r#""HTTP/1.1""#.to_owned(), serde_json::to_string(&wrap).unwrap());
+
+    let wrap = Wrap(None);
+    assert_eq!("null".to_owned(), serde_json::to_string(&wrap).unwrap());
+}


### PR DESCRIPTION
## Summary
Original version of http-serde crate does not support deserialising or serialising `Option<http::Uri>` and so on. This pull request proposes to add support of them as `http_serde::option::*` modules.

## Usages
```rust
use http::*;
use serde::{Serialize, Deserialize};

#[derive(Serialize, Deserialize)]
struct MyStruct {
    #[serde(with = "http_serde::option::header_map")]
    headers: Option<HeaderMap>,

    #[serde(with = "http_serde::option::status_code")]
    status: Option<StatusCode>,

    #[serde(with = "http_serde::option::method")]
    method: Option<Method>,

    #[serde(with = "http_serde::option::uri")]
    uri: Option<Uri>,

    #[serde(with = "http_serde::option::authority")]
    authority: Option<uri::Authority>,

    #[serde(with = "http_serde::option::version")]
    version: Option<Version>,
}
```